### PR TITLE
Poetry install argument

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -24,7 +24,7 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           pip install poetry
-          python -m poetry install --without dev 
+          python -m poetry install 
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       
       - name: Create temp readme


### PR DESCRIPTION
## Changes introduced with this PR

Removing the `--without dev` argument as there are multiple official repositories that do not have this in their toml files. This would force anyone trying to use this reusable workflow to have that exact dev dependency listed or there will be a build time error. I have ran across this in multiple plugins now, and seems to be a new issue as it did not use to create an error if it did not exist. 

Example [error](https://github.com/jdowni000/arcaflow-plugin-kubeconfig/actions/runs/5045987018/jobs/9050935986#:~:text=Group(s)%20not%20found%3A%20dev%20(via%20%2D%2Dwithout))

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).