### PR TITLE
Version control poetry and python version for docsgen

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install poetry==1.3.2
+          pip install poetry==1.4.1
           python -m poetry install 
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -33,7 +33,7 @@ jobs:
           python -m poetry config virtualenvs.in-project true
 
       - name: Cache the virtualenv
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: ./.venv
           key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -23,8 +23,8 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install poetry==1.4.1
-          python -m poetry install 
+          pip install poetry==1.4.2
+          python -m poetry install --without dev --no-root
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       
       - name: Create temp readme

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install poetry
+          pip install poetry=1.4.2
           python -m poetry install 
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Run arcaflow-docsgen
         run: |
-          arcaflow-docsgen -markdown README_TMP.md -schema schema.yaml
+          python -m poetry run arcaflow-docsgen -markdown README_TMP.md -schema schema.yaml
 
       - name: Determine diff
         run: |

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -44,7 +44,7 @@ jobs:
 
       - name: Generate schema yaml
         run: |      
-          python ./${{ inputs.plugin_path }} --schema > schema.yaml
+          python -m poetry run python ./${{ inputs.plugin_path }} --schema > schema.yaml
       
       - name: Create temp readme
         run: |

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -24,7 +24,7 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           pip install poetry
-          pip install pyyaml
+          python -m poetry run pip install pyyaml==6.0.0 --force-reinstall
           python -m poetry install
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install poetry=1.4.2
+          pip install poetry==1.4.2
           python -m poetry install 
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -20,7 +20,7 @@ jobs:
           && tar -C /usr/local/bin -xzf arcaflow-docsgen_0.1.0_linux_amd64.tar.gz
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: 3.9.16
 

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -23,8 +23,9 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install poetry==1.4.2
-          python -m poetry install --without dev --no-root
+          pip install poetry
+          pip install pyyaml
+          python -m poetry install
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       
       - name: Create temp readme

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -19,13 +19,31 @@ jobs:
           wget https://github.com/arcalot/arcaflow-docsgen/releases/download/v0.1.0/arcaflow-docsgen_0.1.0_linux_amd64.tar.gz \
           && tar -C /usr/local/bin -xzf arcaflow-docsgen_0.1.0_linux_amd64.tar.gz
 
-      - name: Generate schema yaml
+      - name: Setup Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9.16
+
+      - name: Install poetry
         run: |
-          python -m venv .venv
-          source .venv/bin/activate
-          pip install poetry
-          python -m poetry run pip install pyyaml==6.0.0 --force-reinstall
+          python -m pip install poetry==1.4.2
+
+      - name: Configure poetry
+        run: |
+          python -m poetry config virtualenvs.in-project true
+
+      - name: Cache the virtualenv
+        uses: actions/cache@v2
+        with:
+          path: ./.venv
+          key: ${{ runner.os }}-venv-${{ hashFiles('**/poetry.lock') }}
+
+      - name: Install dependencies
+        run: |
           python -m poetry install
+
+      - name: Generate schema yaml
+        run: |      
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       
       - name: Create temp readme

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           python -m venv .venv
           source .venv/bin/activate
-          pip install poetry==1.4.2
+          pip install poetry==1.3.2
           python -m poetry install 
           python ./${{ inputs.plugin_path }} --schema > schema.yaml
       


### PR DESCRIPTION
## Changes introduced with this PR

A new change has broke our builds using the latest tags of poetry and python. I am attempting to version control these to match our builds with ACT. Testing was done [here](https://github.com/jdowni000/arcaflow-plugin-template-python/actions/runs/5580329524) with python-template repo.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).