### PR TITLE
Keep `docsgen` from updating protected branches

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -64,7 +64,7 @@ jobs:
           echo "README_DIFF=$(cat arcaflow-docsgen.diff | wc -l)" >> $GITHUB_ENV
       
       - name: Update README.md if necessary
-        if: env.README_DIFF != 0
+        if: env.README_DIFF != 0 && !github.ref_protected
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_EMAIL: arcalot@redhat.com


### PR DESCRIPTION
## Changes introduced with this PR

This PR adds a check to the `docsgen` reusable workflow which skips the step where it updates the branch if the branch is protected (like `main`), because attempting the update will result in an error which will cause the workflow (and the rest of the CI) to fail.

We're not supposed to need updates to protected branches, as the updates are supposed to have been applied to PRs before they are merged, so, under normal circumstances, this change should have no impact. (And, if an update is actually required, it should be detected and applied to the next PR to come along, anyway.)

However, under unusual circumstances (such as when a PR is merged too quickly for the bot to respond, or when the bot is producing [an unstable result](https://github.com/arcalot/arcaflow-plugin-fio/actions/runs/10360556054) (https://github.com/arcalot/arcaflow-plugin-fio/pull/39)) this change will prevent the `main` branch CI from failing.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).