### PR TITLE
Add missing table-row end-tag to the type template

### DIFF
--- a/templates/markdown/partials/type.md.tpl
+++ b/templates/markdown/partials/type.md.tpl
@@ -27,4 +27,4 @@
     {{- partial "one_of_int" .  -}}
 {{- else if eq .TypeID "ref" -}}
     {{- partial "ref" .  -}}
-{{- end -}}
+{{- end -}}</tr>


### PR DESCRIPTION
## Changes introduced with this PR

This change adds a missing `</tr>` tag at the end of the `type` partials template.  The HTML protocol is generous enough that the lack of this tag is ignored by the browser, but it was annoying to me back when I was silly enough to try to review the generated documentation, and the fix is trivial.  However, this will likely prompt the `docsgen` bot to update the documentation for all of the plugins, etc. (but, hopefully, [it will only do it for new PRs, and not the `main` branch](https://github.com/arcalot/arcaflow-docsgen/pull/43)).

Fixes #14.

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).