### PR TITLE
Update workflow for PRs

### DIFF
--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -58,10 +58,7 @@ jobs:
 
       - name: Determine diff
         run: |
-          set +e
-          diff README.md README_TMP.md > arcaflow-docsgen.diff
-          set -e
-          echo "README_DIFF=$(cat arcaflow-docsgen.diff | wc -l)" >> $GITHUB_ENV
+          echo "README_DIFF=$(cmp -s README.md README_TMP.md ; echo $?)" >> $GITHUB_ENV
       
       - name: Update README.md if necessary
         if: env.README_DIFF != 0 && !github.ref_protected

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -60,16 +60,20 @@ jobs:
         run: |
           echo "README_DIFF=$(cmp -s README.md README_TMP.md ; echo $?)" >> $GITHUB_ENV
       
-      - name: Update README.md if necessary
-        if: env.README_DIFF != 0 && !github.ref_protected
+      - name: Update README.md if appropriate
+        # The github.head_ref variable is only available for pull requests,
+        # however, we probably shouldn't be updating the branch for anything
+        # which isn't a PR, anyway!
+        if: env.README_DIFF == 1 && github.event_name == 'pull_request'
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GH_EMAIL: arcalot@redhat.com
           GH_USERNAME: arcabot
         run: |
-          mv README_TMP.md README.md
           git config --global user.name $GH_USERNAME
           git config --global user.email $GH_EMAIL
-          git add README.md
-          git commit -m 'Automatic update of README.md by arcaflow-docsgen arcabot'
+          git switch ${{ github.head_ref }}
+          mv README_TMP.md README.md
+          git commit -m 'Automatic update of README.md by arcaflow-docsgen arcabot' README.md
           git push
+          git switch ${{ github.ref }}

--- a/.github/workflows/reusable_workflow.yaml
+++ b/.github/workflows/reusable_workflow.yaml
@@ -72,8 +72,9 @@ jobs:
         run: |
           git config --global user.name $GH_USERNAME
           git config --global user.email $GH_EMAIL
-          git switch ${{ github.head_ref }}
+          git fetch origin ${{ github.head_ref }}
+          git checkout -f ${{ github.head_ref }}
           mv README_TMP.md README.md
           git commit -m 'Automatic update of README.md by arcaflow-docsgen arcabot' README.md
-          git push
-          git switch ${{ github.ref }}
+          git push origin HEAD:${{ github.head_ref }}
+          git checkout -f refs/remotes/pull/${{ github.ref_name }}


### PR DESCRIPTION
The current workflow is broken when triggered by a PR event (see https://github.com/arcalot/arcaflow-plugin-rtla/pull/1):  the GHA checkout [uses a detached head from a temporary branch](https://github.com/arcalot/arcaflow-plugin-rtla/actions/runs/11611804740/job/32335255241#step:2:62), and so [the attempt to push the update fails](https://github.com/arcalot/arcaflow-plugin-rtla/actions/runs/11611804740/job/32335255241#step:13:29).  (When triggered by a branch update event, it runs [on a "real branch"](https://github.com/arcalot/arcaflow-plugin-rtla/actions/runs/11612337212/job/32335811050#step:2:62), and there's no problem.)

This PR tweaks the update step of the workflow:
- after configuring Git but before making any changes, it switches to the the "head branch" from the PR instead of using the current checkout
- then it moves the updated contents into the `README.md` file and commits it to the branch
- then, after pushing the branch, it switches the checkout back to the original ref

These steps are taken only if the trigger was a pull request (and only if there is a difference in the generated documentation).  The value of `github.head_ref` is only available for PRs, so none of this will work for other triggers.  And, more importantly, I suspect that we _don't want_ this step to run except for PRs -- that is, I don't think we want to bot making changes to branches when no one is supervising.  (The current state disables this step if the branch is protected, but that doesn't seem strict enough to me.)

This PR also streamlines the difference check in a separate commit.

_Note:  until this PR is merged, you can try it out by modifying your plugin workflow to reference `@PR-support` instead of `@main`._

---
By contributing to this repository, I agree to the [contribution guidelines](https://github.com/arcalot/.github/blob/main/CONTRIBUTING.md).